### PR TITLE
12 Add subclasses to Anchor class

### DIFF
--- a/src/manim_eng/_base/component.py
+++ b/src/manim_eng/_base/component.py
@@ -8,7 +8,7 @@ import numpy as np
 from manim_eng._base.mark import Mark, Markable
 from manim_eng._base.terminal import Terminal
 from manim_eng._config import config_eng
-from manim_eng._debug.anchor import Anchor
+from manim_eng._debug.anchor import AnnotationAnchor, CentreAnchor, LabelAnchor
 from manim_eng.circuit.voltage import Voltage
 
 
@@ -41,9 +41,9 @@ class Component(Markable, metaclass=abc.ABCMeta):
 
         self._terminals = terminals
 
-        self._centre_anchor: Anchor
-        self._label_anchor: Anchor
-        self._annotation_anchor: Anchor
+        self._centre_anchor = CentreAnchor()
+        self._label_anchor = LabelAnchor()
+        self._annotation_anchor = AnnotationAnchor()
 
         self._body = mn.VGroup(*self._terminals)
         self.add(self._body)
@@ -231,15 +231,10 @@ class Component(Markable, metaclass=abc.ABCMeta):
         return to_return
 
     def __set_up_anchors(self) -> None:
-        self._centre_anchor = Anchor(config_eng.anchor.centre_colour)
         # A small amount is added to each of these anchors to make sure that they are
         # never directly over the centre anchor, as this causes problems.
-        self._label_anchor = Anchor(config_eng.anchor.label_colour).shift(
-            self._body.get_top() + 0.01 * mn.UP
-        )
-        self._annotation_anchor = Anchor(config_eng.anchor.annotation_colour).shift(
-            self._body.get_bottom() + 0.01 * mn.DOWN
-        )
+        self._label_anchor.shift(self._body.get_top() + 0.01 * mn.UP)
+        self._annotation_anchor.shift(self._body.get_bottom() + 0.01 * mn.DOWN)
         self.add(self._centre_anchor, self._label_anchor, self._annotation_anchor)
 
     def __initialise_marks(self, label: str | None, annotation: str | None) -> None:

--- a/src/manim_eng/_base/terminal.py
+++ b/src/manim_eng/_base/terminal.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from manim_eng._base.mark import Mark, Markable
 from manim_eng._config import config_eng
-from manim_eng._debug.anchor import Anchor
+from manim_eng._debug.anchor import CentreAnchor, CurrentAnchor, TerminalAnchor
 from manim_eng._utils import utils
 
 
@@ -48,12 +48,8 @@ class Terminal(Markable):
         )
         self.add(self.line)
 
-        self._centre_anchor: Anchor = Anchor(config_eng.anchor.centre_colour).move_to(
-            self.line.get_center()
-        )
-        self._end_anchor: Anchor = Anchor(config_eng.anchor.terminal_colour).move_to(
-            position
-        )
+        self._centre_anchor = CentreAnchor().move_to(self.line.get_center())
+        self._end_anchor = TerminalAnchor().move_to(position)
 
         self._current_arrow: CurrentArrow
         self._current_arrow_showing: bool = False
@@ -61,10 +57,10 @@ class Terminal(Markable):
         self.__rebuild_current_arrow()
 
         arrow_half_height = self._current_arrow.height / 2
-        self._top_anchor = Anchor(config_eng.anchor.current_colour).move_to(
+        self._top_anchor = CurrentAnchor().move_to(
             self._centre_anchor.pos + np.array([0, arrow_half_height, 0])
         )
-        self._bottom_anchor = Anchor(config_eng.anchor.current_colour).move_to(
+        self._bottom_anchor = CurrentAnchor().move_to(
             self._centre_anchor.pos + np.array([0, -arrow_half_height, 0])
         )
 

--- a/src/manim_eng/_debug/anchor.py
+++ b/src/manim_eng/_debug/anchor.py
@@ -1,3 +1,5 @@
+import abc
+
 import manim as mn
 import manim.typing as mnt
 import numpy as np
@@ -5,8 +7,8 @@ import numpy as np
 from manim_eng._config import config_eng
 
 
-class Anchor(mn.Arc):
-    def __init__(self, colour: mn.ManimColor):
+class Anchor(mn.Arc, metaclass=abc.ABCMeta):
+    def __init__(self, colour: mn.ManimColor) -> None:
         super().__init__(
             config_eng.anchor.radius if config_eng.debug else 0,
             start_angle=0,
@@ -19,3 +21,33 @@ class Anchor(mn.Arc):
     @property
     def pos(self) -> mnt.Point3D:
         return np.array(self.get_center())
+
+
+class AnnotationAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.annotation_colour)
+
+
+class CentreAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.centre_colour)
+
+
+class CurrentAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.current_colour)
+
+
+class LabelAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.label_colour)
+
+
+class TerminalAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.terminal_colour)
+
+
+class VoltageAnchor(Anchor):
+    def __init__(self) -> None:
+        super().__init__(config_eng.anchor.voltage_colour)

--- a/src/manim_eng/circuit/voltage.py
+++ b/src/manim_eng/circuit/voltage.py
@@ -10,7 +10,7 @@ import manim_eng._utils as utils
 from manim_eng import config_eng
 from manim_eng._base.mark import Mark, Markable
 from manim_eng._base.terminal import Terminal
-from manim_eng._debug.anchor import Anchor
+from manim_eng._debug.anchor import CentreAnchor, VoltageAnchor
 
 __all__ = ["Voltage"]
 
@@ -65,8 +65,8 @@ class Voltage(Markable):
         self._angle_of_direction = mn.angle_of_vector(self._direction)
 
         self._arrow: mn.Arrow = mn.Arrow(mn.ORIGIN, mn.ORIGIN)
-        self._centre_reference: Anchor = Anchor(config_eng.anchor.centre_colour)
-        self._anchor: Anchor = Anchor(config_eng.anchor.voltage_colour)
+        self._centre_reference = CentreAnchor()
+        self._anchor = VoltageAnchor()
 
         self.add_updater(lambda mob: mob.__arrow_updater())
         self.update()


### PR DESCRIPTION
This keeps their usage a bit cleaner and prevents code using them from having to dig into the config and set the colour manually, which isn't that code's responsibility.