### PR TITLE
#18 Add new alignment method for monopoles

### DIFF
--- a/src/manim_eng/components/base/component.py
+++ b/src/manim_eng/components/base/component.py
@@ -105,7 +105,7 @@ class Component(Markable, metaclass=abc.ABCMeta):
         other: Terminal | mnt.Point3D | Node | Monopole,
         direction: mnt.Vector3D | None = None,
     ) -> Self:
-        """Align a component terminal with a point or a terminal on another component.
+        """Align a component terminal with a point or another component.
 
         Moves this component along the line perpendicular to ``direction`` such that the
         line between the end of ``self_terminal`` and ``other``
@@ -135,8 +135,8 @@ class Component(Markable, metaclass=abc.ABCMeta):
             If a string passed to ``self_terminal`` does not represent an attribute of
             this component that produces a ``Terminal`` instance.
         ValueError
-            If ``other_terminal`` belongs to this component (if it is a ``Terminal``)
-            or if ``other_terminal`` *is* this component (if it is a ``Node`` or
+            If ``other`` belongs to this component (if it is a ``Terminal``)
+            or if ``other`` *is* this component (if it is a ``Node`` or
             ``Monopole``).
 
         Notes

--- a/src/manim_eng/components/base/monopole.py
+++ b/src/manim_eng/components/base/monopole.py
@@ -1,5 +1,7 @@
 """Contains the Monopole base class."""
 
+from __future__ import annotations
+
 import abc
 from typing import Any, Self
 
@@ -8,6 +10,7 @@ import manim.typing as mnt
 
 from manim_eng.components.base.component import Component
 from manim_eng.components.base.terminal import Terminal
+from manim_eng.components.node import Node
 
 __all__ = ["Monopole"]
 
@@ -39,6 +42,46 @@ class Monopole(Component, metaclass=abc.ABCMeta):
     def terminal(self) -> Terminal:
         """Get the terminal of the component."""
         return self.terminals[0]
+
+    def align_monopole(
+        self,
+        other: Terminal | mnt.Point3D | Node | Monopole,
+        direction: mnt.Vector3D | None = None,
+    ) -> Self:
+        """Aligns the monopole's terminal with another point or component.
+
+        Moves this component along the line perpendicular to ``direction`` such that the
+        line between the end of this component's terminal and ``other``
+        has direction vector ``direction``.
+
+        Parameters
+        ----------
+        other : Terminal | Point3D | Node | Monopole
+            A ``Terminal`` belonging to another component, a ``Node``, a ``Monopole``
+            (for which its single terminal is selected), or a point in space.
+        direction : Vector3D | None
+            The direction to align the terminals in. If not supplied, uses
+            ``self_terminal``'s direction.
+
+        Raises
+        ------
+        ValueError
+            If ``other`` belongs to this component (if it is a ``Terminal``)
+            or if ``other`` *is* this component (if it is a ``Node`` or
+            ``Monopole``).
+
+        Notes
+        -----
+        In geometric terms, the component in moved such that the end of
+        this monopole's terminal is at the intersection of the lines that
+
+        - Have direction vector perpendicular to ``direction`` and go through the
+          current position of the end of this monopole's terminal; and
+        - Have direction vector ``direction`` and go through the end of
+          ``other`` (in the case that it is a ``Terminal``) or through ``other`` (in the
+           case that it is a point).
+        """
+        return super().align_terminal(self.terminal, other, direction)
 
     def set_annotation(self, annotation: str) -> Self:
         """Fails for monopoles, as they do not have annotations."""


### PR DESCRIPTION
This doesn't require a terminal to be specified because monopoles only have one terminal, so it's obvious which terminal was intended.