### PR TITLE
#28 Rename from_terminal, to_terminal to start, end

### DIFF
--- a/src/manim_eng/circuit/base/wire.py
+++ b/src/manim_eng/circuit/base/wire.py
@@ -19,17 +19,17 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
     wire should have corners.
     """
 
-    def __init__(self, from_terminal: Terminal, to_terminal: Terminal, updating: bool):
+    def __init__(self, start: Terminal, end: Terminal, updating: bool):
         super().__init__(stroke_width=config_eng.symbol.wire_stroke_width)
 
-        if from_terminal == to_terminal:
+        if start == end:
             raise ValueError(
-                "`from_terminal` and `to_terminal` are identical. "
+                "`start` and `end` are identical. "
                 "Wires must have different terminals at each end."
             )
 
-        self.from_terminal = from_terminal
-        self.to_terminal = to_terminal
+        self.start = start
+        self.end = end
 
         self.__construct_wire()
 
@@ -41,8 +41,8 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
 
         This updates the terminals so that they know they have one more connection.
         """
-        self.from_terminal._increment_connection_count()
-        self.to_terminal._increment_connection_count()
+        self.start._increment_connection_count()
+        self.end._increment_connection_count()
         return self
 
     def detach(self) -> Self:
@@ -50,8 +50,8 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
 
         This updates the terminals so that they know they have one fewer connection.
         """
-        self.from_terminal._decrement_connection_count()
-        self.to_terminal._decrement_connection_count()
+        self.start._decrement_connection_count()
+        self.end._decrement_connection_count()
         return self
 
     def __construct_wire(self) -> None:
@@ -60,11 +60,11 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
         # wire
         self.set_points_as_corners(
             [
-                self.from_terminal.end - 0.001 * self.from_terminal.direction,
-                self.from_terminal.end,
+                self.start.end - 0.001 * self.start.direction,
+                self.start.end,
                 *self.get_corner_points(),
-                self.to_terminal.end,
-                self.to_terminal.end - 0.001 * self.to_terminal.direction,
+                self.end.end,
+                self.end.end - 0.001 * self.end.direction,
             ]
         )
 
@@ -81,8 +81,8 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
         if anim_args is None:
             anim_args = {}
         return mn.AnimationGroup(
-            self.from_terminal.animate(**anim_args)._increment_connection_count(),
-            self.to_terminal.animate(**anim_args)._increment_connection_count(),
+            self.start.animate(**anim_args)._increment_connection_count(),
+            self.end.animate(**anim_args)._increment_connection_count(),
         )
 
     @mn.override_animate(detach)
@@ -90,8 +90,8 @@ class WireBase(mn.VMobject, metaclass=abc.ABCMeta):
         if anim_args is None:
             anim_args = {}
         return mn.AnimationGroup(
-            self.from_terminal.animate(**anim_args)._decrement_connection_count(),
-            self.to_terminal.animate(**anim_args)._decrement_connection_count(),
+            self.start.animate(**anim_args)._decrement_connection_count(),
+            self.end.animate(**anim_args)._decrement_connection_count(),
         )
 
     @mn.override_animation(mn.Create)

--- a/src/manim_eng/circuit/circuit.py
+++ b/src/manim_eng/circuit/circuit.py
@@ -66,14 +66,14 @@ class Circuit(mn.VMobject):
         self.components.remove(*components)
         return self
 
-    def connect(self, from_terminal: Terminal, to_terminal: Terminal) -> Self:
+    def connect(self, start: Terminal, end: Terminal) -> Self:
         """Connect two terminals together.
 
         Parameters
         ----------
-        from_terminal : Terminal
+        start : Terminal
             The terminal the connecting wire should start at.
-        to_terminal : Terminal
+        end : Terminal
             The terminal the connecting wire should end at.
 
         Raises
@@ -83,8 +83,8 @@ class Circuit(mn.VMobject):
         ValueError
             If either terminal doesn't belong to a component in this circuit.
         """
-        self.__check_terminals_all_belong_to_this_circuit([from_terminal, to_terminal])
-        self.wires.add(Wire(from_terminal, to_terminal).attach())
+        self.__check_terminals_all_belong_to_this_circuit([start, end])
+        self.wires.add(Wire(start, end).attach())
         self.nodes.update()
         return self
 
@@ -193,8 +193,8 @@ class Circuit(mn.VMobject):
         to_remove = []
         for wire in cast(list[Wire], self.wires.submobjects):
             if condition(
-                wire.from_terminal in terminals,
-                wire.to_terminal in terminals,
+                wire.start in terminals,
+                wire.end in terminals,
             ):
                 to_remove.append(wire)
         return to_remove
@@ -219,20 +219,20 @@ class Circuit(mn.VMobject):
     @mn.override_animate(connect)
     def __animate_connect(
         self,
-        from_terminal: Terminal,
-        to_terminal: Terminal,
+        start: Terminal,
+        end: Terminal,
         anim_args: dict[str, Any] | None = None,
     ) -> mn.Animation:
         if anim_args is None:
             anim_args = {}
 
-        self.__check_terminals_all_belong_to_this_circuit([from_terminal, to_terminal])
-        if from_terminal == to_terminal:
+        self.__check_terminals_all_belong_to_this_circuit([start, end])
+        if start == end:
             raise ValueError(
-                "`from_terminal` and `to_terminal` are identical. "
+                "`start` and `end` are identical. "
                 "`connect()` requires two different terminals."
             )
-        new_wire = Wire(from_terminal, to_terminal)
+        new_wire = Wire(start, end)
         self.wires.add(new_wire)
         return mn.AnimationGroup(
             mn.Create(new_wire, **anim_args),

--- a/src/manim_eng/circuit/voltage.py
+++ b/src/manim_eng/circuit/voltage.py
@@ -20,10 +20,10 @@ class Voltage(Markable):
 
     Parameters
     ----------
-    from_terminal : Terminal
+    start : Terminal
         The terminal the non-tip end of the arrow should be attached to, i.e. the
         'negative' end.
-    to_terminal : Terminal
+    end : Terminal
         The terminal the tip end of the arrow should be attached to, i.e. the 'positive'
         end.
     label : str
@@ -44,8 +44,8 @@ class Voltage(Markable):
 
     def __init__(
         self,
-        from_terminal: Terminal,
-        to_terminal: Terminal,
+        start: Terminal,
+        end: Terminal,
         label: str,
         clockwise: bool = False,
         buff: float = mn.SMALL_BUFF,
@@ -54,14 +54,14 @@ class Voltage(Markable):
     ) -> None:
         super().__init__()
 
-        self.from_terminal = from_terminal
-        self.to_terminal = to_terminal
+        self.start = start
+        self.end = end
         self.clockwise = clockwise
         self.buff = buff
         self.component_to_avoid = avoid
         self.component_buff = component_buff
 
-        self._direction = to_terminal.end - from_terminal.end
+        self._direction = end.end - start.end
         self._angle_of_direction = mn.angle_of_vector(self._direction)
 
         self._arrow: mn.Arrow = mn.Arrow(mn.ORIGIN, mn.ORIGIN)
@@ -135,47 +135,47 @@ class Voltage(Markable):
         return self.set_clockwise(clockwise=False)
 
     def set_terminals(
-        self, from_terminal: Terminal | None = None, to_terminal: Terminal | None = None
+        self, start: Terminal | None = None, end: Terminal | None = None
     ) -> Self:
         """Set the terminal(s) the arrow goes from/to.
 
         Parameters
         ----------
-        from_terminal : Terminal | None
+        start : Terminal | None
             The terminal to attach the start of the arrow to.
-        to_terminal : Terminal | None
+        end : Terminal | None
             The terminal to attach the end of the arrow to.
 
         Raises
         ------
         ValueError
-            If neither `from_terminal` or `to_terminal` are specified.
+            If neither `start` or `end` are specified.
 
         See Also
         --------
-        set_from_terminal
-        set_to_terminal
+        set_start
+        set_end
         """
-        if from_terminal == to_terminal is None:
-            raise ValueError("Neither `from_terminal` nor `to_terminal` specified.")
-        if from_terminal is not None:
-            self.from_terminal = from_terminal
-        if to_terminal is not None:
-            self.to_terminal = to_terminal
+        if start == end is None:
+            raise ValueError("Neither `start` nor `end` specified.")
+        if start is not None:
+            self.start = start
+        if end is not None:
+            self.end = end
         self.update()
         return self
 
-    def set_from_terminal(self, terminal: Terminal) -> Self:
-        """Set the terminal the arrow should point from.
+    def set_start(self, terminal: Terminal) -> Self:
+        """Set the terminal the arrow should start from.
 
         Parameters
         ----------
         terminal : Terminal
             The terminal that should be at the non-tip end of the voltage arrow.
         """
-        return self.set_terminals(from_terminal=terminal)
+        return self.set_terminals(start=terminal)
 
-    def set_to_terminal(self, terminal: Terminal) -> Self:
+    def set_end(self, terminal: Terminal) -> Self:
         """Set the terminal the arrow should point to.
 
         Parameters
@@ -183,7 +183,7 @@ class Voltage(Markable):
         terminal : Terminal
             The terminal that should be at the tip end of the voltage arrow.
         """
-        return self.set_terminals(to_terminal=terminal)
+        return self.set_terminals(end=terminal)
 
     def flip_direction(self, flip_sense_as_well: bool = True) -> Self:
         """Flip the direction of the voltage arrow.
@@ -195,14 +195,14 @@ class Voltage(Markable):
             or anticlockwise to clockwise), so that the arrow remains on the same side
             of the component. Defaults to ``True``.
         """
-        self.from_terminal, self.to_terminal = self.to_terminal, self.from_terminal
+        self.start, self.end = self.end, self.start
         if flip_sense_as_well:
             self.clockwise ^= True
         self.update()
         return self
 
     def __arrow_updater(self) -> None:
-        self._direction = self.to_terminal.end - self.from_terminal.end
+        self._direction = self.end.end - self.start.end
         self._angle_of_direction = mn.angle_of_vector(self._direction)
 
         self.__update_arrow()
@@ -226,8 +226,8 @@ class Voltage(Markable):
             angle *= -1
 
         new_arrow = mn.Arrow(
-            start=self.from_terminal.end,
-            end=self.to_terminal.end,
+            start=self.start.end,
+            end=self.end.end,
             path_arc=angle,
             stroke_width=config_eng.symbol.arrow_stroke_width,
             tip_length=config_eng.symbol.arrow_tip_length,
@@ -308,7 +308,7 @@ class Voltage(Markable):
 
         Calculates the necessary angle to be swept by the voltage arrow's arc for it to
         pass through ``middle_point`` as well as its endpoints defined by the
-        ``from_terminal`` and ``to_terminal`` as passed to the constructor.
+        ``start`` and ``end`` as passed to the constructor.
 
         In all cases two possible angles are available, one reflex and one not. This
         method will always return the non-reflex one. As such, avoid passing in points
@@ -318,7 +318,7 @@ class Voltage(Markable):
         ----------
         middle_point : Point3D
             The extra point the arrow should pass through, as well as the two end points
-            defined by the ``from`` and ``to`` terminals.
+            defined by the ``start`` and ``end`` terminals.
 
         Returns
         -------
@@ -340,10 +340,10 @@ class Voltage(Markable):
         equations from the vector equations of the bisectors and solving for the scaling
         factors.
         """
-        chord_ab = middle_point - self.from_terminal.end
-        chord_bc = self.to_terminal.end - middle_point
+        chord_ab = middle_point - self.start.end
+        chord_bc = self.end.end - middle_point
 
-        mid_ab = self.from_terminal.end + chord_ab / 2
+        mid_ab = self.start.end + chord_ab / 2
         mid_bc = middle_point + chord_bc / 2
 
         perp_ab = np.cross(chord_ab, mn.OUT)

--- a/src/manim_eng/circuit/wire.py
+++ b/src/manim_eng/circuit/wire.py
@@ -18,15 +18,15 @@ class ManualWire(WireBase):
 
     Parameters
     ----------
-    from_terminal : Terminal
+    start : Terminal
         The terminal the wire starts at.
-    to_terminal : Terminal
+    end : Terminal
         The terminal the wire ends at.
     corner_points : Sequence[Point3D]
         The vertices the line should have between the two terminals. Should not include
         the positions of the two terminals, as these are inserted automatically when the
-        wire is drawn. These should be in order from ``from_terminal`` to
-        ``to_terminal``.
+        wire is drawn. These should be in order from ``start`` to
+        ``end``.
     updating : bool
         Whether the ends of the wire should update automatically to keep connected to
         the terminals. This is disabled by default. If this is enabled, it is
@@ -36,17 +36,17 @@ class ManualWire(WireBase):
     Raises
     ------
     ValueError
-        If ``from_terminal`` and ``to_terminal`` are the same.
+        If ``start`` and ``end`` are the same.
     """
 
     def __init__(
         self,
-        from_terminal: Terminal,
-        to_terminal: Terminal,
+        start: Terminal,
+        end: Terminal,
         corner_points: Sequence[mnt.Point3D],
         updating: bool = False,
     ):
-        super().__init__(from_terminal, to_terminal, updating)
+        super().__init__(start, end, updating)
 
         self.corner_points = list(corner_points)
 
@@ -68,19 +68,19 @@ class Wire(WireBase):
 
     Parameters
     ----------
-    from_terminal : Terminal
+    start : Terminal
         The terminal the wire starts at.
-    to_terminal : Terminal
+    end : Terminal
         The terminal the wire ends at.
 
     Raises
     ------
     ValueError
-        If ``from_terminal`` and ``to_terminal`` are the same.
+        If ``start`` and ``end`` are the same.
     """
 
-    def __init__(self, from_terminal: Terminal, to_terminal: Terminal) -> None:
-        super().__init__(from_terminal, to_terminal, updating=True)
+    def __init__(self, start: Terminal, end: Terminal) -> None:
+        super().__init__(start, end, updating=True)
 
     def get_corner_points(self) -> list[mnt.Point3D]:
         """Get the corner points of the wire.
@@ -88,8 +88,8 @@ class Wire(WireBase):
         Returns the vertices of the wire, not including the end points (i.e. at the
         start and end terminals).
         """
-        from_direction = utils.cardinalised(self.from_terminal.direction)
-        to_direction = utils.cardinalised(self.to_terminal.direction)
+        from_direction = utils.cardinalised(self.start.direction)
+        to_direction = utils.cardinalised(self.end.direction)
 
         if np.isclose(np.dot(from_direction, to_direction), 0):
             return self.__get_corner_points_for_perpendicular_terminals(
@@ -102,8 +102,8 @@ class Wire(WireBase):
     def __get_corner_points_for_perpendicular_terminals(
         self, from_direction: mnt.Vector3D, to_direction: mnt.Vector3D
     ) -> list[mnt.Point3D]:
-        from_end = self.from_terminal.end
-        to_end = self.to_terminal.end
+        from_end = self.start.end
+        to_end = self.end.end
 
         corner_point = mn.find_intersection(
             [from_end], [from_direction], [to_end], [to_direction]
@@ -125,13 +125,13 @@ class Wire(WireBase):
     def __get_corner_points_for_parallel_terminals(
         self, from_direction: mnt.Vector3D, to_direction: mnt.Vector3D
     ) -> list[mnt.Point3D]:
-        midpoint = mn.midpoint(self.from_terminal.end, self.to_terminal.end)
+        midpoint = mn.midpoint(self.start.end, self.end.end)
 
         to_behind_from = self.__point_is_behind_plane(
-            self.to_terminal.end, self.from_terminal.end, from_direction
+            self.end.end, self.start.end, from_direction
         )
         from_behind_to = self.__point_is_behind_plane(
-            self.from_terminal.end, self.to_terminal.end, to_direction
+            self.start.end, self.end.end, to_direction
         )
 
         if to_behind_from and from_behind_to:
@@ -143,18 +143,18 @@ class Wire(WireBase):
         # direction, so we really want an elbow rather than an 'S'
         elif to_behind_from:
             midpoint = self.__move_point_forward_of_plane(
-                midpoint, self.from_terminal.end, from_direction
+                midpoint, self.start.end, from_direction
             )
         elif from_behind_to:
             midpoint = self.__move_point_forward_of_plane(
-                midpoint, self.to_terminal.end, to_direction
+                midpoint, self.end.end, to_direction
             )
 
         perpendicular_direction = np.cross(from_direction, mn.OUT)
         corner_points = mn.find_intersection(
             [midpoint] * 2,
             [perpendicular_direction] * 2,
-            [self.from_terminal.end, self.to_terminal.end],
+            [self.start.end, self.end.end],
             [from_direction, to_direction],
         )
         return list(corner_points)

--- a/src/manim_eng/components/base/component.py
+++ b/src/manim_eng/components/base/component.py
@@ -339,8 +339,8 @@ class Component(Markable, metaclass=abc.ABCMeta):
 
     def voltage(
         self,
-        from_terminal: Terminal | str,
-        to_terminal: Terminal | str,
+        start: Terminal | str,
+        end: Terminal | str,
         *args: Any,
         **kwargs: Any,
     ) -> Voltage:
@@ -353,10 +353,10 @@ class Component(Markable, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        from_terminal : Terminal | str
+        start : Terminal | str
             Either a ``Terminal`` belonging to this component, or a string representing
             an attribute of this component that returns a terminal (e.g. ``"right"``).
-        to_terminal : Terminal | str
+        end : Terminal | str
             Either a ``Terminal`` belonging to this component, or a string representing
             an attribute of this component that returns a terminal (e.g. ``"left"``).
         *args
@@ -381,20 +381,20 @@ class Component(Markable, metaclass=abc.ABCMeta):
             If a string passed for either terminal does not represent an attribute of
             this component that produces a ``Terminal`` instance.
         ValueError
-            If the terminals specified for both 'from' and 'to' are the same.
+            If the terminals specified for both ``start`` and ``end`` are the same.
         """
-        from_terminal = self._get_or_check_terminal(from_terminal)
-        to_terminal = self._get_or_check_terminal(to_terminal)
+        start = self._get_or_check_terminal(start)
+        end = self._get_or_check_terminal(end)
 
-        if from_terminal == to_terminal:
+        if start == end:
             raise ValueError(
-                "The terminals specified through `from_terminal` and `to_terminal` are "
+                "The terminals specified through `start` and `end` are "
                 "identical. They must be different."
             )
 
         kwargs["avoid"] = self
 
-        return Voltage(from_terminal, to_terminal, *args, **kwargs)
+        return Voltage(start, end, *args, **kwargs)
 
     def _get_or_check_terminal(self, terminal: Terminal | str | None) -> Terminal:
         """Get a terminal or check a passed terminal belongs to this component.

--- a/tests/circuit_test.py
+++ b/tests/circuit_test.py
@@ -15,8 +15,8 @@ def test_connect() -> None:
 
     for submobjects in [circuit.wires.submobjects, circuit_animated.wires.submobjects]:
         assert len(submobjects) == 1
-        assert submobjects[0].from_terminal == component_1.left
-        assert submobjects[0].to_terminal == component_2.right
+        assert submobjects[0].start == component_1.left
+        assert submobjects[0].end == component_2.right
 
 
 def test_connect_throws_value_error_if_terminals_are_identical(
@@ -24,13 +24,9 @@ def test_connect_throws_value_error_if_terminals_are_identical(
 ) -> None:
     circuit = Circuit(dummy_component)
 
-    with pytest.raises(
-        ValueError, match="`from_terminal` and `to_terminal` are identical"
-    ):
+    with pytest.raises(ValueError, match="`start` and `end` are identical"):
         circuit.connect(dummy_component.left, dummy_component.left)
-    with pytest.raises(
-        ValueError, match="`from_terminal` and `to_terminal` are identical"
-    ):
+    with pytest.raises(ValueError, match="`start` and `end` are identical"):
         circuit.animate.connect(dummy_component.left, dummy_component.left)
 
 
@@ -68,8 +64,8 @@ def test_disconnect() -> None:
 
     for submobjects in [circuit.wires.submobjects, circuit_animated.wires.submobjects]:
         assert len(submobjects) == 1
-        assert submobjects[0].from_terminal == component_1.left
-        assert submobjects[0].to_terminal == component_2.left
+        assert submobjects[0].start == component_1.left
+        assert submobjects[0].end == component_2.left
 
 
 def test_disconnect_throws_error_if_terminals_do_not_belong_to_components_in_circuit(
@@ -109,8 +105,8 @@ def test_isolate() -> None:
 
     for submobjects in [circuit.wires.submobjects, circuit_animated.wires.submobjects]:
         assert len(submobjects) == 1
-        assert submobjects[0].from_terminal == component_2.right
-        assert submobjects[0].to_terminal == component_3.right
+        assert submobjects[0].start == component_2.right
+        assert submobjects[0].end == component_3.right
 
 
 def test_isolate_throws_error_if_terminals_do_not_belong_to_components_in_the_circuit(

--- a/tests/component_test.py
+++ b/tests/component_test.py
@@ -138,14 +138,14 @@ def test_voltage_processes_terminals_correctly(dummy_component: DummyComponent) 
     voltage_3 = dummy_component.voltage(dummy_component.left, "right", "V")
     voltage_4 = dummy_component.voltage("left", "right", "V")
 
-    assert voltage_1.from_terminal == dummy_component.left
-    assert voltage_1.to_terminal == dummy_component.right
-    assert voltage_2.from_terminal == dummy_component.left
-    assert voltage_2.to_terminal == dummy_component.right
-    assert voltage_3.from_terminal == dummy_component.left
-    assert voltage_3.to_terminal == dummy_component.right
-    assert voltage_4.from_terminal == dummy_component.left
-    assert voltage_4.to_terminal == dummy_component.right
+    assert voltage_1.start == dummy_component.left
+    assert voltage_1.end == dummy_component.right
+    assert voltage_2.start == dummy_component.left
+    assert voltage_2.end == dummy_component.right
+    assert voltage_3.start == dummy_component.left
+    assert voltage_3.end == dummy_component.right
+    assert voltage_4.start == dummy_component.left
+    assert voltage_4.end == dummy_component.right
 
 
 def test_voltage_sets_component_it_is_called_on_as_avoid(
@@ -160,8 +160,7 @@ def test_voltage_errors_if_terminals_are_the_same(
     dummy_component: DummyComponent,
 ) -> None:
     expected_message = (
-        "The terminals specified through `from_terminal` and "
-        "`to_terminal` are identical."
+        "The terminals specified through `start` and `end` are identical."
     )
 
     with pytest.raises(ValueError, match=expected_message):

--- a/tests/wire_test.py
+++ b/tests/wire_test.py
@@ -9,7 +9,7 @@ def test_wire_throws_value_error_if_terminals_are_identical() -> None:
 
     with pytest.raises(
         ValueError,
-        match=r"`from_terminal` and `to_terminal` are identical\. "
+        match=r"`start` and `end` are identical\. "
         r"Wires must have different terminals at each end\.",
     ):
         Wire(terminal, terminal)
@@ -20,7 +20,7 @@ def test_manual_wire_throws_value_error_if_terminals_are_identical() -> None:
 
     with pytest.raises(
         ValueError,
-        match=r"`from_terminal` and `to_terminal` are identical\. "
+        match=r"`start` and `end` are identical\. "
         r"Wires must have different terminals at each end\.",
     ):
         ManualWire(terminal, terminal, [])


### PR DESCRIPTION
This brings the API in line with the rest of Manim, and is less verbose and generally clearer.