### PR TITLE
Fix debug mode leakage

### DIFF
--- a/docs/source/extending_manim-eng/custom_components.rst
+++ b/docs/source/extending_manim-eng/custom_components.rst
@@ -417,6 +417,7 @@ should hopefully illuminate.
     config.frame_width = 5
     config.pixel_width = 1000
     config.pixel_height = 600
+    config_eng.debug = False
 
     class OutlineModifierExample(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/adding_components.rst
+++ b/docs/source/first_circuit_diagram/adding_components.rst
@@ -25,6 +25,7 @@ symbols.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self) -> None:
@@ -47,6 +48,7 @@ In our target circuit, the resistor is vertical, so let's quickly fix that.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self) -> None:
@@ -77,6 +79,7 @@ also add in the second resistor.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -114,6 +117,7 @@ Let's add some labels to our components. This is done using the
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/adding_wires.rst
+++ b/docs/source/first_circuit_diagram/adding_wires.rst
@@ -34,6 +34,7 @@ does the rest.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -80,6 +81,7 @@ We can then connect the rest together in the same way.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -150,6 +152,7 @@ the terminals that something is attached to them! This gives us the below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -195,6 +198,7 @@ Let's add in the third connection to the top node.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -250,6 +254,7 @@ any of those, so we just pass ``0``. Our result is then what we expected.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -313,6 +318,7 @@ Speaking of adding the second node, let's do just that!
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/animations.rst
+++ b/docs/source/first_circuit_diagram/animations.rst
@@ -58,6 +58,7 @@ shown below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -142,6 +143,7 @@ We can do the same for everything else as well! Let's take a look.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/circuit_class.rst
+++ b/docs/source/first_circuit_diagram/circuit_class.rst
@@ -48,6 +48,7 @@ result is as below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/index.rst
+++ b/docs/source/first_circuit_diagram/index.rst
@@ -8,6 +8,7 @@ shown below (fans of CircuiTikZ may recognise this example!)
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/first_circuit_diagram/voltage_and_current_labels.rst
+++ b/docs/source/first_circuit_diagram/voltage_and_current_labels.rst
@@ -51,6 +51,7 @@ This gives us a beautiful voltage arrow as below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -133,6 +134,7 @@ This gives us the result below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):
@@ -208,6 +210,7 @@ We'll adjust the ``component_buff`` for our purposes.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CurrentShunt(Scene):
         def construct(self):

--- a/docs/source/guides/circuits.rst
+++ b/docs/source/guides/circuits.rst
@@ -57,6 +57,7 @@ been :ref:`added <add_components_to_circuits>` first.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CircuitExample(Scene):
         def construct(self):
@@ -116,6 +117,7 @@ end of the wire are passed as arguments. In the example below, we disconnect |R1
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CircuitExample(Scene):
         def construct(self):
@@ -159,6 +161,7 @@ To drive the point about needing to pass both ends home, if we just one end spec
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CircuitExample(Scene):
         def construct(self):
@@ -208,6 +211,7 @@ removed.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CircuitExample(Scene):
         def construct(self):
@@ -269,6 +273,7 @@ capabilities outlined on this page is below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class CircuitExample(Scene):
         def construct(self):

--- a/docs/source/guides/components.rst
+++ b/docs/source/guides/components.rst
@@ -32,6 +32,7 @@ All components have two ways for setting labels and annotations: the
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class SettingLabelsAndAnnotations(Scene):
         def construct(self):
@@ -70,6 +71,7 @@ in action together.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class SettingLabelsAndAnnotations(Scene):
         def construct(self):
@@ -156,6 +158,7 @@ Let's take a look at an example to see what this means in practice.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class SetVsReset(Scene):
         def construct(self):
@@ -261,6 +264,7 @@ another component's terminal. Let's take a look at an example.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class AlignTerminal(Scene):
         def construct(self):
@@ -290,6 +294,7 @@ but without requiring the terminal to be specified.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class AlignMonopole(Scene):
         def construct(self):

--- a/docs/source/guides/marks.rst
+++ b/docs/source/guides/marks.rst
@@ -24,6 +24,7 @@ look at what this means with a label on a resistor.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class RotatingResistor(Scene):
         def construct(self):
@@ -52,6 +53,7 @@ cardinal and sub-cardinal alignment regions, respectively.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class LinedSector(Sector):
         def __init__(self, **kwargs):
@@ -141,6 +143,7 @@ Wrapping this in the necessary Manim boilerplate, we see the below.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class LabelledResistor(Scene):
         def construct(self):
@@ -176,6 +179,7 @@ best demonstrated through the use of an example.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class UnitExpressionLabel(Scene):
         def construct(self):
@@ -193,6 +197,7 @@ units.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class UnitExpressionLabel(Scene):
         def construct(self):
@@ -226,6 +231,7 @@ notation. The following example demonstrates this.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class UnitExpressionLabel(Scene):
         def construct(self):

--- a/docs/source/guides/voltages.rst
+++ b/docs/source/guides/voltages.rst
@@ -26,6 +26,7 @@ should take.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class SimpleVoltageArrow(Scene):
         def construct(self):
@@ -60,6 +61,7 @@ through movements of the components, including animated movements.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class SimpleVoltageArrow(Scene):
         def construct(self):
@@ -101,6 +103,7 @@ terminals of the resistors.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class VoltageArrowClockwise(Scene):
         def construct(self):
@@ -137,6 +140,7 @@ this to the test.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class VoltageArrowClockwise(Scene):
         def construct(self):
@@ -167,6 +171,7 @@ course use your own arbitrary values as well).
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     config.frame_width = 4
     config.pixel_width = 500
@@ -189,6 +194,7 @@ course use your own arbitrary values as well).
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     config.frame_width = 4
     config.pixel_width = 500
@@ -211,6 +217,7 @@ course use your own arbitrary values as well).
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     config.frame_width = 4
     config.pixel_width = 500
@@ -233,6 +240,7 @@ course use your own arbitrary values as well).
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     config.frame_width = 4
     config.pixel_width = 500
@@ -275,6 +283,7 @@ Let's take a look at what this means with a single, unlabelled resistor.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class VoltageArrowAvoid(Scene):
         def construct(self):
@@ -301,6 +310,7 @@ That doesn't seem all that special, but what if we add a label to the resistor?
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class VoltageArrowAvoid(Scene):
         def construct(self):

--- a/docs/source/guides/wiring.rst
+++ b/docs/source/guides/wiring.rst
@@ -33,6 +33,7 @@ attached are moved, the wire will plan a new path seamlessly.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class WireBasics(Scene):
         def construct(self):
@@ -84,6 +85,7 @@ demonstrated in the example below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class StrangeAutomaticWiring(Scene):
         def construct(self):
@@ -142,6 +144,7 @@ then the terminals of ``node 1`` and ``node 2`` would be updated to display *bef
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class WhyNotAttachAutomatically(Scene):
         def construct(self):
@@ -166,6 +169,7 @@ is. As an aside, if we actually run the code above, we see the below...
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class WhyNotAttachAutomatically(Scene):
         def construct(self):
@@ -227,6 +231,7 @@ manim-eng calls **autoblobbing**. Let's take a look at an example.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class AutoblobbingExample(Scene):
         def construct(self):
@@ -269,6 +274,7 @@ we see the below.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class AutoblobbingExample(Scene):
         def construct(self):
@@ -326,6 +332,7 @@ Let's examine the simple example of a potential divider.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class PotentialDivider(Scene):
         def construct(self):
@@ -353,6 +360,7 @@ put that right with an animation. We'll add the following lines to our scene.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class PotentialDivider(Scene):
         def construct(self):
@@ -389,6 +397,7 @@ with one another. Using this updater gives us the below.
     :hide_source:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class PotentialDivider(Scene):
         def construct(self):
@@ -454,6 +463,7 @@ the below displays a two-port network low-pass filter.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class LowPassFilter(Scene):
         def construct(self):
@@ -520,6 +530,7 @@ it facilitates diagonal wires.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class Switchboard(Scene):
         def construct(self):
@@ -560,6 +571,7 @@ switchboard example.
     :save_last_frame:
 
     from manim_eng import *
+    config_eng.debug = False
 
     class Switchboard(Scene):
         def construct(self):


### PR DESCRIPTION
The environment used by the manim directive is leaky and shared between invocations. This can lead to the debug mode leaking into other visualisations.

Though it's not pretty, the best solution I've found so far is to explicitly set the debug mode to False at the start of each manim directive invocation which doesn't require the debug mode.